### PR TITLE
feat: Add token dsETH and gtcETH to constant

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -20,6 +20,8 @@
     <div class="index_web_widget" data-widget-type="chart-token-allocation" data-token-symbol="DPI"></div>
     <!-- <div class="index_web_widget" data-widget-type="chart-token-allocation" data-token-symbol="MVI"></div> -->
     <!-- <div class="index_web_widget" data-widget-type="chart-token-allocation" data-token-symbol="BED"></div> -->
+    <div class="index_web_widget" data-widget-type="chart-token-allocation" data-token-symbol="DSETH"></div>
+    <div class="index_web_widget" data-widget-type="chart-token-allocation" data-token-symbol="GTCETH"></div>
 
     <!-- Price (Line Chart) -->
     <div class="index_web_widget" data-widget-type="chart-token-line" data-token-symbol="DPI"></div>

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -94,6 +94,26 @@ export const DefiPulseIndex: Token = {
   defaultChain: MAINNET.chainId,
 };
 
+export const DiversifiedStakedETHIndex: Token = {
+  name: 'Diversified Staked ETH Index',
+  symbol: 'dsETH',
+  image:
+    'https://assets.website-files.com/60d237b6ea65be721ff4bbfa/637daed7345b29db5929e009_Dseth%20Logo.png',
+  address: '0x341c05c0E9b33C0E38d64de76516b2Ce970bB3BE',
+  polygonAddress: undefined,
+  optimismAddress: undefined,
+  decimals: 18,
+  url: 'dseth',
+  coingeckoId: 'diversified-staked-eth',
+  tokensetsId: 'dseth',
+  fees: {
+    streamingFee: '0.25%',
+  },
+  isDangerous: false,
+  indexTypes: [IndexType.yield],
+  defaultChain: MAINNET.chainId,
+};
+
 export const ETH: Token = {
   name: 'Ethereum',
   symbol: 'ETH',
@@ -131,6 +151,26 @@ export const Ethereum2xFlexibleLeverageIndex: Token = {
   defaultChain: MAINNET.chainId,
 };
 
+export const GitcoinStakedETHIndex: Token = {
+  name: 'Gitcoin Staked ETH Index',
+  symbol: 'gtcETH',
+  image:
+    'https://assets.website-files.com/60d237b6ea65be721ff4bbfa/63f3a853c42e2e45ee6076c6_gtcETH-logo-p-500.png',
+  address: '0x36c833Eed0D376f75D1ff9dFDeE260191336065e',
+  polygonAddress: undefined,
+  optimismAddress: undefined,
+  decimals: 18,
+  url: 'gtceth',
+  coingeckoId: 'gitcoin-staked-eth-index',
+  tokensetsId: 'gtceth',
+  fees: {
+    streamingFee: '2.0%',
+  },
+  isDangerous: false,
+  indexTypes: [IndexType.yield],
+  defaultChain: MAINNET.chainId,
+};
+
 export const MetaverseIndex: Token = {
   name: 'Metaverse Index',
   symbol: 'MVI',
@@ -155,6 +195,8 @@ export const ProductTokensBySymbol = {
   BED: BedIndex,
   BTCFLI: Bitcoin2xFlexibleLeverageIndex,
   DPI: DefiPulseIndex,
+  DSETH: DiversifiedStakedETHIndex,
   ETHFLI: Ethereum2xFlexibleLeverageIndex,
+  GTCETH: GitcoinStakedETHIndex,
   MVI: MetaverseIndex,
 };


### PR DESCRIPTION
## **Summary of Changes**

Add two more tokens to constants. Supports pie charts for them

## **Test Data or Screenshots**

dsETH
<img width="408" alt="Screen Shot 2023-03-11 at 1 08 47 PM" src="https://user-images.githubusercontent.com/13758946/224459703-9575e536-9eed-4ed3-b8ba-e4837a9c266d.png">

gtcETH
<img width="403" alt="Screen Shot 2023-03-11 at 1 09 05 PM" src="https://user-images.githubusercontent.com/13758946/224459710-7189f801-01b9-430a-a5eb-dd85a6c3deeb.png">

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
